### PR TITLE
Replace AM_CONFIG_HEADER with AC_CONFIG_HEADERS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.68])
 AC_INIT([addrwatch], [0.7], [julius.kriukas@gmail.com])
 AM_INIT_AUTOMAKE([-Wall foreign check-news silent-rules -Werror])
 AC_CONFIG_SRCDIR([src/addrwatch.c])
-AM_CONFIG_HEADER([src/config.h])
+AC_CONFIG_HEADERS([src/config.h])
 
 # Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
I am not an autotools expert not by even a long shot, but on newer systems this change makes it possible to complete autoreconf -fvi without seeing errors about AM_CONFIG_HEADER being a obsolete macro. 

Kind regards,
Athanasios
