### PR TITLE
Remove sys_siglist usage in favor of strsignal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,9 +58,6 @@ AC_CHECK_HEADERS([arpa/inet.h netinet/in.h stdint.h stdlib.h syslog.h unistd.h])
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
 AC_TYPE_PID_T
-AC_CHECK_DECLS([sys_siglist], [], [
-	AC_MSG_ERROR([Unable to find sys_siglist declaration.])
-], [[#include <signal.h>]])
 AC_TYPE_UINT32_T
 AC_TYPE_UINT16_T
 AC_TYPE_UINT8_T

--- a/src/addrwatch.c
+++ b/src/addrwatch.c
@@ -327,7 +327,7 @@ void reload_cb(evutil_socket_t fd, short events, void *arg)
 void reload_cb(int fd, short events, void *arg)
 #endif
 {
-	log_msg(LOG_DEBUG, "Received signal (%d), %s", fd, sys_siglist[fd]);
+	log_msg(LOG_DEBUG, "Received signal (%d), %s", fd, strsignal(fd));
 	log_msg(LOG_DEBUG, "Reopening output files");
 
 	output_flatfile_reload();
@@ -341,7 +341,7 @@ void stop_cb(evutil_socket_t fd, short events, void *arg)
 void stop_cb(int fd, short events, void *arg)
 #endif
 {
-	log_msg(LOG_DEBUG, "Received signal (%d), %s", fd, sys_siglist[fd]);
+	log_msg(LOG_DEBUG, "Received signal (%d), %s", fd, strsignal(fd));
 #if HAVE_LIBEVENT2
 	event_base_loopbreak(cfg.eb);
 #else


### PR DESCRIPTION
This is more portable. Musl libc for example, does not support sys_siglist