### PR TITLE
addrwatch: use HOST_NAME_MAX instead of _SC

### DIFF
--- a/src/addrwatch.c
+++ b/src/addrwatch.c
@@ -501,7 +501,7 @@ int main(int argc, char *argv[])
 	argp_parse(&argp, argc, argv, 0, &optind, 0);
 
 	if (!cfg.hostname) {
-		cfg.hostname_len = sysconf(_SC_HOST_NAME_MAX);
+		cfg.hostname_len = HOST_NAME_MAX;
 		cfg.hostname = (char *)calloc(cfg.hostname_len, sizeof(char));
 		gethostname(cfg.hostname, cfg.hostname_len);
 	}


### PR DESCRIPTION
The latter is not defined with some libcs.