### PR TITLE
More specific library linking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ optional_modules=""
 AC_SUBST([optional_modules])
 
 # Checks for libraries.
-AC_CHECK_LIB([pcap], [pcap_open_live])
+AC_CHECK_LIB([pcap], [pcap_open_live], :)
 AC_CHECK_LIB([rt], [shm_open])
 
 PKG_CHECK_MODULES(LIBEVENT, [libevent >= 1.4], , [
@@ -46,7 +46,7 @@ AC_ARG_ENABLE([sqlite3],
 )
 AC_ARG_ENABLE([mysql],
     AS_HELP_STRING([--enable-mysql], [Enable MySQL database output]),
-    AC_CHECK_LIB([mysqlclient], [mysql_real_connect], , [
+    AC_CHECK_LIB([mysqlclient], [mysql_real_connect], :, [
     	AC_MSG_ERROR([Unable to find libmysqlclient.])
     ])
     optional_modules="${optional_modules} addrwatch_mysql"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,5 +9,6 @@ addrwatch_stdout_SOURCES = addrwatch_stdout.c shm_client.c shm_client.h
 addrwatch_syslog_SOURCES = addrwatch_syslog.c shm_client.c shm_client.h
 addrwatch_mysql_SOURCES = addrwatch_mysql.c shm_client.c shm_client.h util.c util.h
 
-addrwatch_LDADD = @LIBEVENT_LIBS@
+addrwatch_LDADD = @LIBEVENT_LIBS@ -lpcap
+addrwatch_mysql_LDADD = -lmysqlclient
 


### PR DESCRIPTION
Currently, the main binary and all output modules are linked to the same set of libraries. This changes the linking so that only the main binary is linked to pcap, and only addrwatch_mysql is linked to mysqlclient.

This allows the main binary and output modules to be packaged separately with fewer dependencies for each individual package.