### PR TITLE
Fix int type in string format for uint64_t timestamp in logging (stdout and syslog), issues #25, #26

### DIFF
--- a/src/addrwatch_stdout.c
+++ b/src/addrwatch_stdout.c
@@ -1,6 +1,7 @@
 #include "shm.h"
 #include "shm_client.h"
 
+#include <inttypes.h>
 #include <netinet/in.h>
 #include <stdio.h>
 
@@ -16,8 +17,8 @@ void process_entry(struct shm_log_entry *e, void *arg)
 		ip4_ntoa(e->ip_address, ip_str);
 	}
 
-	printf("%llu %s %u %s %s %s\n", e->timestamp, e->interface, e->vlan_tag,
-		mac_str, ip_str, pkt_origin_str[e->origin]);
+	printf("%" PRId64 " %s %u %s %s %s\n", e->timestamp, e->interface,
+		e->vlan_tag, mac_str, ip_str, pkt_origin_str[e->origin]);
 }
 
 int main(int argc, char *argv[])

--- a/src/addrwatch_stdout.c
+++ b/src/addrwatch_stdout.c
@@ -16,7 +16,7 @@ void process_entry(struct shm_log_entry *e, void *arg)
 		ip4_ntoa(e->ip_address, ip_str);
 	}
 
-	printf("%lu %s %u %s %s %s\n", e->timestamp, e->interface, e->vlan_tag,
+	printf("%llu %s %u %s %s %s\n", e->timestamp, e->interface, e->vlan_tag,
 		mac_str, ip_str, pkt_origin_str[e->origin]);
 }
 

--- a/src/addrwatch_syslog.c
+++ b/src/addrwatch_syslog.c
@@ -1,6 +1,7 @@
 #include "shm.h"
 #include "shm_client.h"
 
+#include <inttypes.h>
 #include <netinet/in.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,7 +19,7 @@ void process_entry(struct shm_log_entry *e, void *arg)
 		ip4_ntoa(e->ip_address, ip_str);
 	}
 
-	syslog(LOG_INFO, "%llu %s %u %s %s %s", e->timestamp, e->interface,
+	syslog(LOG_INFO, "%" PRId64 " %s %u %s %s %s", e->timestamp, e->interface,
 		e->vlan_tag, mac_str, ip_str, pkt_origin_str[e->origin]);
 }
 

--- a/src/addrwatch_syslog.c
+++ b/src/addrwatch_syslog.c
@@ -18,7 +18,7 @@ void process_entry(struct shm_log_entry *e, void *arg)
 		ip4_ntoa(e->ip_address, ip_str);
 	}
 
-	syslog(LOG_INFO, "%lu %s %u %s %s %s", e->timestamp, e->interface,
+	syslog(LOG_INFO, "%llu %s %u %s %s %s", e->timestamp, e->interface,
 		e->vlan_tag, mac_str, ip_str, pkt_origin_str[e->origin]);
 }
 

--- a/src/output_flatfile.c
+++ b/src/output_flatfile.c
@@ -1,6 +1,8 @@
 #include "output_flatfile.h"
 #include "util.h"
 
+#include <inttypes.h>
+
 void output_flatfile_init()
 {
 	if (cfg.data_file) {
@@ -22,7 +24,7 @@ void output_flatfile_reload()
 void output_flatfile_save(struct pkt *p, char *mac_str, char *ip_str)
 {
 	if (cfg.data_fd) {
-		fprintf(cfg.data_fd, "%lu %s %u %s %s %s\n",
+		fprintf(cfg.data_fd, "%" PRId64 " %s %u %s %s %s\n",
 			p->pcap_header->ts.tv_sec, p->ifc->name, p->vlan_tag,
 			mac_str, ip_str, pkt_origin_str[p->origin]);
 		fflush(cfg.data_fd);


### PR DESCRIPTION
This simple modification fixed for me the problems #25 and #26 that occur on Arm devices (an OpenWRT router, and a RaspberryPi). It should work properly on all other architectures since `%llu` format [should be (at least) 64 bit everywhere](https://en.wikipedia.org/wiki/C_data_types). You may want to test it though.
