### PR TITLE
Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Building from repo
 
 If sources are obtained directly from the git repository (instead of
 distribution source package) project has to be bootstrapped using
-autoreconf/automake. A helper shell script `bottstrap.sh` is included in the
+autoreconf/automake. A helper shell script `bootstrap.sh` is included in the
 repository for that. Note that bootstraping autotools project requires autoconf
 and automake to be available on the system.
 


### PR DESCRIPTION
Fixed typo `bottstrap.sh` that should be `bootstrap`